### PR TITLE
Address team renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Traits Working Group
+# Types Team
 
-# Scope and purpose
+## Scope and purpose
 
-The **traits** working group is dedicated to improving the trait
-system implementation in rustc. This working group is a collaboration
+The **types** team is dedicated to improving the trait
+system implementation in rustc. This team is a collaboration
 between the [lang team] and the compiler team. We have a number of inter-related
 goals:
 
@@ -32,17 +32,16 @@ You'll find minutes from past meetings in [the minutes directory](minutes).
 
 ## Chat forum
 
-On [the rust-lang Zulip][z], in [the `#wg-traits` stream][s].
+On [the rust-lang Zulip][z], in [the `#t-types` stream][s].
 
 [z]: https://rust-lang.zulipchat.com/
-[s]: https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits
+[s]: https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types
 
 ## Dedicated repository
 
-Documents related to the wg-traits working group are stored on a
-dedicated repository, [rust-lang/wg-traits]. This repository contains
+Documents related to the types team are stored on a
+dedicated repository, [rust-lang/types-team]. This repository contains
 meeting minutes, past sprints, as well as draft RFCs and other
 documents.
 
-
-
+[rust-lang/types-team]: https://github.com/rust-lang/types-team

--- a/book.toml
+++ b/book.toml
@@ -3,4 +3,4 @@ authors = ["Niko Matsakis"]
 language = "en"
 multilingual = false
 src = "src"
-title = "The Traits Working Group"
+title = "The Types Team"

--- a/roadmap.toml
+++ b/roadmap.toml
@@ -71,7 +71,7 @@ items = [
 [[group]]
 name = "map-chalk-types-to-rustc-types"
 label = "Map chalk types to rustc types"
-href = "https://github.com/rust-lang/wg-traits/issues/16"
+href = "https://github.com/rust-lang/types-team/issues/16"
 items = [
   { label = "Rename Projection to Alias", status="Complete" }, 
   { label = "Make ty intern method take &amp;self", href="https://github.com/rust-lang-nursery/chalk/issues/328", status="Complete" },
@@ -112,7 +112,7 @@ items = [
 [[group]]
 name = "rustc-integration-mvp"
 label = "Integrate chalk-solve into rustc"
-href = "https://github.com/rust-lang/wg-traits/issues/18"
+href = "https://github.com/rust-lang/types-team/issues/18"
 requires = [ "map-chalk-types-to-rustc-types", "chalk-const", "chalk-builtin", "chalk-outlives" ]
 items = [
   { label="remove old chalk support", status="Complete", href="https://github.com/rust-lang/rust/pull/69247" },
@@ -150,4 +150,3 @@ requires = [ "rustc-integration-mvp", "rust-analyzer-integration", "chalk-debugg
 name = "gats"
 label = "Deploy GATs in Rust nightly"
 requires = [ "align-rustc-predicate" ]
-

--- a/src/minutes.md
+++ b/src/minutes.md
@@ -1,4 +1,4 @@
 Minutes from various meetings are located in [the `minutes` directory
 on the github repository][minutes].
 
-[minutes]: https://github.com/rust-lang/wg-traits/tree/master/minutes
+[minutes]: https://github.com/rust-lang/types-team/tree/master/minutes

--- a/src/roadmap.md
+++ b/src/roadmap.md
@@ -12,7 +12,8 @@ these issue lists on Github:
 We are working from a 6-week "sprint cycle". We're still working out
 the details of how we organize our sprints. For now, if you'd like to
 claim one of the above issues or get involved, though, drop by on [the
-rust-lang Zulip] in the `#wg-traits` stream and say hello!
+rust-lang Zulip] in the [`#t-types`] stream and say hello!
 
 [the rust-lang Zulip]: https://rust-lang.zulipchat.com/
+[`#t-types`]: https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types
 [dr]: roadmap/skill-tree.html

--- a/src/welcome.md
+++ b/src/welcome.md
@@ -1,9 +1,9 @@
-# Welcome to the traits working group
+# Welcome to the types team
 
 ## Scope and purpose
 
-The **traits** working group is dedicated to improving the trait
-system implementation in rustc. This working group is a collaboration
+The **types** team is dedicated to improving the trait
+system implementation in rustc. This team is a collaboration
 between the [lang team] and the compiler team. We have a number of inter-related
 goals:
 
@@ -36,7 +36,16 @@ meetings.
 
 ## Chat forum
 
-On [the rust-lang Zulip][z], in [the `#wg-traits` stream][s].
+On [the rust-lang Zulip][z], in [the `#t-types` stream][s].
 
 [z]: https://rust-lang.zulipchat.com/
-[s]: https://rust-lang.zulipchat.com/#narrow/stream/144729-wg-traits
+[s]: https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types
+
+## Dedicated repository
+
+Documents related to the types team are stored on a
+dedicated repository, [rust-lang/types-team]. This repository contains
+meeting minutes, past sprints, as well as draft RFCs and other
+documents.
+
+[rust-lang/types-team]: https://github.com/rust-lang/types-team


### PR DESCRIPTION
While I was updating rustc-dev-guide in https://github.com/rust-lang/rustc-dev-guide/pull/1360, also noticed this repo isn't updated yet. This largely replaces wg-traits with t-types except for the past minutes.