### PR TITLE
Update README.md with correct calendar event link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ topics ([calendar event][ce-design]).  These meetings take place on Zulip (see b
 not just to figure out what we want to do, it's also a way to spread
 knowledge. Feel free to come and lurk!
 
-[ce-design]: https://calendar.google.com/event?action=TEMPLATE&tmeid=MnFmbmdkaGV0aXE3Zjc4cjlpNWVjNDRoZXMgNnU1cnJ0Y2U2bHJ0djA3cGZpM2RhbWdqdXNAZw&tmsrc=6u5rrtce6lrtv07pfi3damgjus%40group.calendar.google.com
+[ce-design]: https://calendar.google.com/calendar/u/0/embed?src=6u5rrtce6lrtv07pfi3damgjus@group.calendar.google.com
 
 You'll find minutes from past meetings in [the minutes directory](minutes).
 


### PR DESCRIPTION
The calendar event link currently just renders a blank page. I managed to find a new/correct link from https://rust-lang.zulipchat.com/#narrow/stream/144729-t-types/topic/How.20is.20one.20to.20find.20her.20way.20around.20here/near/385867428